### PR TITLE
Removed Bootstrap and Font Awesome as dependencies in bower.json.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,9 +30,9 @@
     "karma.conf.js"
   ],
   "dependencies": {
-    "angular": ">=1.3.0",
-    "bootstrap": ">=3.2.0",
-    "font-awesome": ">=4.0.3",
+    "angular": ">=1.3.0"
+  },
+  "devDependencies": {
     "angular-mocks": "~1.4.1"
   },
   "homepage": "https://github.com/turinggroup/angular-validator"


### PR DESCRIPTION
As Bootstrap is not a requirement when using angular-validator, I removed Bootstrap (and Font Awesome) in order to avoid having to install it for projects that don't use Bootstrap or jQuery (Bootstrap dependency).

I also moved angular-mocks to become a dev-dependency.