### PR TITLE
move all dependencies to the devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "scripts": {
     "test": "grunt test --verbose"
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-browser-sync": "^2.2.0",
     "grunt-cli": "^1.2.0",


### PR DESCRIPTION
This directive does not need any dependencies for doing its job in an Angular app.
Now when we install `angular-validator` via NPM all packages under actual "dependencies" comes with this package - but we don't need them. In my computer the installation even fails because incompatibility of required "dependencies" with my NodeJS. Please move all "dependencies" to the "devDependencies".