### PR TITLE
Fix/update broken Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "0.10"
   - "0.11"
-  - "node" # latest stable Node.js release
+  - "node"  # latest stable Node.js release
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "0.10"
   - "0.11"
+  - "node"  # latest stable Node.js release
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "0.10"
   - "0.11"
-  - "node"  # latest stable Node.js release
+  - "node" # latest stable Node.js release
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 sudo: false  # use container-based virtualization environment
 language: node_js
 node_js:
-  - "0.10"
-  - "0.11"
-  - "6"  # most recent Node.js LTS until Oct 2017, https://github.com/nodejs/lts
+  - "6"  # Node.js LTS maintained until April 2019, https://github.com/nodejs/lts
   - "node"  # latest stable Node.js release
 before_script:
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
+sudo: false  # use container-based virtualization environment
 language: node_js
 node_js:
   - "0.10"
   - "0.11"
+  - "6"  # most recent Node.js LTS until Oct 2017, https://github.com/nodejs/lts
   - "node"  # latest stable Node.js release
 before_script:
   - export DISPLAY=:99.0

--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "jquery": "~2.1.4"
   },
   "devDependencies": {
-    "angular-mocks": "~1.4.1",
+    "angular-mocks": "^1.6.2",
     "angular-messages": "^1.6.2"
   },
   "homepage": "https://github.com/turinggroup/angular-validator"


### PR DESCRIPTION
* match devDependencies versions with each other (was trying to install conflicting versions of angular)
* remove old/EOL'd versions of NodeJS, added newer ones
* explicitly switched to container-based travis builds (shorter builds)